### PR TITLE
1.6.1

### DIFF
--- a/ToolbarManager/Config.cs
+++ b/ToolbarManager/Config.cs
@@ -22,6 +22,7 @@ namespace ToolbarManager
         #region Options
         
         private bool enableStagingArea = true;
+        private bool preventOverwritingSlots = true;
         private bool useCharacterProfilesForBuildCockpit = true;
         
         private bool keepBlockSearchText;
@@ -49,6 +50,13 @@ namespace ToolbarManager
             set => SetField(ref enableStagingArea, value);
         }
         
+        [Checkbox(label: "Prevent overwriting slots", description: "Prevent overwriting the selected or first toolbar slot on double-clicking blocks")]
+        public bool PreventOverwritingSlots
+        {
+            get => preventOverwritingSlots;
+            set => SetField(ref preventOverwritingSlots, value);
+        }
+
         [Checkbox(label: "Build cockpit is character", description: "Building from cockpit (Ctrl-G) uses the character profiles")]
         public bool UseCharacterProfilesForBuildCockpit
         {

--- a/ToolbarManager/Properties/AssemblyInfo.cs
+++ b/ToolbarManager/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.6.0.0")]
+[assembly: AssemblyVersion("1.6.1.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]
 
 // Game assemblies to publicize
 [assembly: IgnoresAccessChecksTo("Sandbox.Game")]


### PR DESCRIPTION
- Prevent overwriting the selected or first toolbar slot on double-clicking blocks