### PR TITLE
1.6.2

### DIFF
--- a/ToolbarManager/Config.cs
+++ b/ToolbarManager/Config.cs
@@ -22,6 +22,7 @@ namespace ToolbarManager
         #region Options
         
         private bool enableStagingArea = true;
+        private int stagingAreaRowCount = 2;
         private bool preventOverwritingSlots = true;
         private bool useCharacterProfilesForBuildCockpit = true;
         
@@ -48,6 +49,13 @@ namespace ToolbarManager
         {
             get => enableStagingArea;
             set => SetField(ref enableStagingArea, value);
+        }
+        
+        [Slider(1f, 8f, 1f, SliderAttribute.SliderType.Integer, label: "Staging rows", description: "Number of rows visible in the staging area [1..8]")]
+        public int StagingAreaRowCount
+        {
+            get => stagingAreaRowCount;
+            set => SetField(ref stagingAreaRowCount, value);
         }
         
         [Checkbox(label: "Prevent overwriting slots", description: "Prevent overwriting the selected or first toolbar slot on double-clicking blocks")]

--- a/ToolbarManager/Patches/MyGuiScreenToolbarConfigBasePatch.cs
+++ b/ToolbarManager/Patches/MyGuiScreenToolbarConfigBasePatch.cs
@@ -73,7 +73,8 @@ namespace ToolbarManager.Patches
             
             // Sizes
             const float spacing = 0.002f;
-            const float stagingHeight = 0.208f;
+            const float cellHeight = 0.07f;
+            var stagingHeight = 0.208f + cellHeight * (Cfg.StagingAreaRowCount - 2f);
             var stagingLabelHeight = toolbarLabel.Size.Y;
             var gridBlocksPanelHeight = availableHeight - spacing - stagingLabelHeight - spacing - stagingHeight + /* WHY??? */ 0.058f;
             
@@ -89,7 +90,7 @@ namespace ToolbarManager.Patches
             stagingLabel.ColorMask = toolbarLabel.ColorMask;
             stagingLabel.TextScale = toolbarLabel.TextScale;
             stagingLabel.OriginAlign = MyGuiDrawAlignEnum.HORISONTAL_LEFT_AND_VERTICAL_TOP;
-            stagingLabel.Position = topLeft + new Vector2(0f, gridBlocksPanelHeight + spacing) + /* WHY??? */ new Vector2(0.17f, 0.065f);
+            stagingLabel.Position = topLeft + new Vector2(0f, gridBlocksPanelHeight + spacing) + /* WHY??? */ new Vector2(0.17f, 0.063f);
             stagingLabel.Size = new Vector2(0.15f, stagingLabelHeight);
             
             // Staging grid and scrollable panel
@@ -113,7 +114,7 @@ namespace ToolbarManager.Patches
             stagingPanel.Position = stagingLabel.Position + new Vector2(0f, stagingLabelHeight + spacing);
             stagingPanel.Size = new Vector2(panelWidth, stagingHeight - 0.05f);
             
-            toolbarLabel.Position += new Vector2(0f, 0.018f);
+            toolbarLabel.Position += new Vector2(0f, 0.004f);
             
             __instance.AddControl(stagingLabel);
             __instance.AddControl(stagingPanel);

--- a/ToolbarManager/Properties/AssemblyInfo.cs
+++ b/ToolbarManager/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.1.0")]
-[assembly: AssemblyFileVersion("1.6.1.0")]
+[assembly: AssemblyVersion("1.6.2.0")]
+[assembly: AssemblyFileVersion("1.6.2.0")]
 
 // Game assemblies to publicize
 [assembly: IgnoresAccessChecksTo("Sandbox.Game")]

--- a/ToolbarManager/ToolbarManager.csproj
+++ b/ToolbarManager/ToolbarManager.csproj
@@ -36,6 +36,9 @@
         <Reference Include="0Harmony, Version=2.3.6.0, Culture=neutral, processorArchitecture=MSIL">
             <HintPath>..\packages\Lib.Harmony.2.3.6\lib\net48\0Harmony.dll</HintPath>
         </Reference>
+        <Reference Include="ProtoBuf.Net.Core">
+          <HintPath>..\Bin64\ProtoBuf.Net.Core.dll</HintPath>
+        </Reference>
         <Reference Include="Sandbox.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
             <HintPath>..\Bin64\Sandbox.Common.dll</HintPath>
         </Reference>


### PR DESCRIPTION
- Configurable number of visible rows in the staging area
- Swapping items instead of overwriting them while moving them inside the staging area
- Allowing only a single instance of each toolbar item in the staging area (considering action and parameters)